### PR TITLE
fix: Handle list in detection_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ A simple GUI application for creating automated bot scripts that can find images
 
 ## Changelog
 
+### v0.6.4 - (2025-08-20)
+- **Right-click action.**
+- Added **Right-click** as a new action type for simple actions.
+- The UI in the Step Editor has been updated to include this new option.
+- The automation engine now correctly performs a right-click when specified.
+
 ### v0.6.3 - (2025-08-20)
 - **Screen Region Locking & Bug Fix.**
 - **New Feature**: Added **Screen Region Locking**. Users can now define a specific sub-region within a target window for an action to search in. This greatly improves performance and reliability when working with large or complex application windows.
@@ -113,14 +119,13 @@ A simple GUI application for creating automated bot scripts that can find images
 - [x] Multiple Image Matching (OR logic in one step)
 - [x] Image Similarity Threshold (fuzzy matching)
 - [x] Screen Region Locking: Restrict actions to specific areas
-
+- [x] Right-click Actions
 
 ---
 
 ### 🛠 v0.6 – Core Automation Expansion
 - [ ] Keyboard Shortcuts: Key combos (Ctrl+Alt+Del, etc.)
 - [ ] Mouse Wheel Actions (scrolling support)
-- [ ] Right-click Actions
 
 ---
 

--- a/automation.py
+++ b/automation.py
@@ -15,6 +15,19 @@ def click_at(x, y):
     mouse.click(Button.left, 1)
     print(f"Clicked at ({x}, {y})")
 
+def right_click_at(x, y):
+    """
+    Moves the mouse to the given coordinates and performs a right click.
+
+    :param x: The x-coordinate.
+    :param y: The y-coordinate.
+    """
+    mouse = MouseController()
+    mouse.position = (x, y)
+    time.sleep(0.1) # Small delay to ensure mouse has moved
+    mouse.click(Button.right, 1)
+    print(f"Right-clicked at ({x}, {y})")
+
 def type_text(text):
     """
     Types the given string using the keyboard.

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import cv2
 from PIL import Image, ImageTk
 from screen_capture import capture_screen
 from image_analyzer import find_color, find_image
-from automation import click_at, type_text, click_and_drag
+from automation import click_at, right_click_at, type_text, click_and_drag
 from settings_manager import SettingsManager
 
 class App(tk.Tk):
@@ -682,6 +682,9 @@ class App(tk.Tk):
             if action_type == "Click":
                 self.log(f"    - Performing action: Click at ({abs_x}, {abs_y})")
                 click_at(abs_x, abs_y)
+            elif action_type == "Right-click":
+                self.log(f"    - Performing action: Right-click at ({abs_x}, {abs_y})")
+                right_click_at(abs_x, abs_y)
             elif action_type == "Click with Offset":
                 offset_x = action_params.get('click_offset_x', 0)
                 offset_y = action_params.get('click_offset_y', 0)
@@ -1156,7 +1159,16 @@ class StepEditor(tk.Toplevel):
             self.target_color_bgr = self.step_data.get('detection_target', [0,0,255])
         else:
             self.target_color_bgr = [0,0,255] # Default value
-        self.template_var = tk.StringVar(value=os.path.basename(self.step_data.get('detection_target', '')) if self.step_data.get('detection_mode') == 'Image' else '')
+        # This var is legacy, from before multi-image support. It's not actively used, but we'll initialize it safely.
+        detection_target = self.step_data.get('detection_target')
+        initial_template_name = ''
+        if self.step_data.get('detection_mode') == 'Image' and detection_target:
+            if isinstance(detection_target, list):
+                if detection_target: # Ensure list is not empty
+                    initial_template_name = os.path.basename(detection_target[0])
+            elif isinstance(detection_target, str):
+                initial_template_name = os.path.basename(detection_target)
+        self.template_var = tk.StringVar(value=initial_template_name)
 
         # Vars for Conditional Loop
         self.max_retries = tk.StringVar(value=self.step_data.get('max_retries', '5'))
@@ -1267,6 +1279,7 @@ class StepEditor(tk.Toplevel):
         action_frame = tk.LabelFrame(parent_frame, text="3. Choose Action", bg=self.master.bg_color, fg=self.master.text_color, padx=5, pady=5)
         action_frame.pack(pady=10, padx=10, fill="x")
         tk.Radiobutton(action_frame, text="Click", variable=self.action_type, value="Click", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
+        tk.Radiobutton(action_frame, text="Right-click", variable=self.action_type, value="Right-click", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
         tk.Radiobutton(action_frame, text="Click with Offset", variable=self.action_type, value="Click with Offset", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
         tk.Radiobutton(action_frame, text="Type", variable=self.action_type, value="Type", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
 
@@ -1518,7 +1531,7 @@ class StepEditor(tk.Toplevel):
         elif action == "Click with Offset":
             self.type_entry_frame.pack_forget()
             self.simple_offset_frame.pack(fill="x", padx=15, pady=2)
-        else:  # Click
+        else:  # Click or Right-click
             self.type_entry_frame.pack_forget()
             self.simple_offset_frame.pack_forget()
 


### PR DESCRIPTION
This commit fixes a TypeError that occurred when editing a step with multiple image templates. The `StepEditor` was not correctly handling the case where `detection_target` is a list of paths.

This change makes the initialization of a legacy variable in the `StepEditor` more robust by checking if `detection_target` is a list and handling it appropriately.