### PR TITLE
feat: Add Keyboard Shortcut Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Here’s a "Hello World" style tutorial to get you started:
 
 ## Changelog
 
+### v0.6.6 - (2025-08-22)
+- **Keyboard Shortcut Actions.**
+- Added **Key Combo** as a new action type, allowing the bot to press key combinations like `Ctrl+C` or `Alt+F4`.
+
 ### v0.6.5 - (2025-08-21)
 - **Mouse Wheel Actions.**
 - Added **Scroll** as a new action type, allowing the bot to scroll up or down.
@@ -143,9 +147,9 @@ Here’s a "Hello World" style tutorial to get you started:
 
 ---
 
-### 🛠 v0.6 – Core Automation Expansion
+### ✅ v0.6 – Core Automation Expansion (Completed)
 - [x] Mouse Wheel Actions (scrolling support)
-- [ ] Keyboard Shortcuts: Key combos (Ctrl+Alt+Del, etc.)
+- [x] Keyboard Shortcuts: Key combos (Ctrl+Alt+Del, etc.)
 
 ---
 

--- a/automation.py
+++ b/automation.py
@@ -1,6 +1,96 @@
 from pynput.mouse import Button, Controller as MouseController
-from pynput.keyboard import Controller as KeyboardController
+from pynput.keyboard import Key, Controller as KeyboardController
 import time
+
+# --- Key Mapping ---
+# Maps string representations to pynput Key objects
+KEY_MAP = {
+    'alt': Key.alt, 'alt_l': Key.alt_l, 'alt_r': Key.alt_r,
+    'alt_gr': Key.alt_gr, 'backspace': Key.backspace, 'caps_lock': Key.caps_lock,
+    'cmd': Key.cmd, 'cmd_l': Key.cmd_l, 'cmd_r': Key.cmd_r,
+    'ctrl': Key.ctrl, 'ctrl_l': Key.ctrl_l, 'ctrl_r': Key.ctrl_r,
+    'delete': Key.delete, 'down': Key.down, 'end': Key.end,
+    'enter': Key.enter, 'esc': Key.esc, 'f1': Key.f1, 'f2': Key.f2,
+    'f3': Key.f3, 'f4': Key.f4, 'f5': Key.f5, 'f6': Key.f6, 'f7': Key.f7,
+    'f8': Key.f8, 'f9': Key.f9, 'f10': Key.f10, 'f11': Key.f11,
+    'f12': Key.f12, 'f13': Key.f13, 'f14': Key.f14, 'f15': Key.f15,
+    'f16': Key.f16, 'f17': Key.f17, 'f18': Key.f18, 'f19': Key.f19,
+    'f20': Key.f20, 'home': Key.home, 'left': Key.left,
+    'page_down': Key.page_down, 'page_up': Key.page_up, 'right': Key.right,
+    'shift': Key.shift, 'shift_l': Key.shift_l, 'shift_r': Key.shift_r,
+    'space': Key.space, 'tab': Key.tab, 'up': Key.up,
+    'media_play_pause': Key.media_play_pause, 'media_volume_mute': Key.media_volume_mute,
+    'media_volume_down': Key.media_volume_down, 'media_volume_up': Key.media_volume_up,
+    'media_previous': Key.media_previous, 'media_next': Key.media_next,
+    'insert': Key.insert, 'menu': Key.menu, 'num_lock': Key.num_lock,
+    'pause': Key.pause, 'print_screen': Key.print_screen, 'scroll_lock': Key.scroll_lock
+}
+
+def _parse_key_string(key_string):
+    """
+    Parses a user-friendly key combination string (e.g., 'ctrl+alt+delete')
+    into a list of modifier keys and a single main key.
+    """
+    parts = [part.strip().lower() for part in key_string.split('+')]
+    modifiers = []
+    main_key = None
+
+    for part in parts:
+        if part in KEY_MAP:
+            # It's a special key, check if it's a modifier
+            key_obj = KEY_MAP[part]
+            if key_obj in [Key.ctrl, Key.alt, Key.shift, Key.cmd]:
+                 modifiers.append(key_obj)
+            else:
+                # It's a special key but not a modifier (e.g., 'delete', 'enter')
+                if main_key is not None:
+                    raise ValueError(f"Invalid key combination: Cannot have more than one non-modifier key. Found '{main_key}' and '{part}'.")
+                main_key = key_obj
+        elif len(part) == 1:
+            # It's a regular character key
+            if main_key is not None:
+                raise ValueError(f"Invalid key combination: Cannot have more than one non-modifier key. Found '{main_key}' and '{part}'.")
+            main_key = part
+        else:
+            raise ValueError(f"Invalid key part: '{part}' in '{key_string}'")
+
+    if main_key is None:
+        raise ValueError(f"Invalid key combination: No main key found in '{key_string}'.")
+
+    return modifiers, main_key
+
+
+def press_key_combination(key_string):
+    """
+    Presses a combination of keys, like "ctrl+c" or "alt+f4".
+
+    :param key_string: A string representing the key combination (e.g., "ctrl+alt+delete").
+    """
+    keyboard = KeyboardController()
+    try:
+        modifiers, main_key = _parse_key_string(key_string)
+
+        # Press all modifier keys
+        for mod in modifiers:
+            keyboard.press(mod)
+
+        # Press and release the main key
+        keyboard.press(main_key)
+        keyboard.release(main_key)
+
+        # Release all modifier keys in reverse order
+        for mod in reversed(modifiers):
+            keyboard.release(mod)
+
+        print(f"Pressed key combination: '{key_string}'")
+        return True
+    except ValueError as e:
+        print(f"Error pressing key combination '{key_string}': {e}")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred while pressing keys: {e}")
+        return False
+
 
 def click_at(x, y):
     """
@@ -116,6 +206,25 @@ if __name__ == '__main__':
 
     print("\nTesting scroll up...")
     scroll_wheel('up', 5)
+    time.sleep(1)
+
+    # Test key combinations
+    print("\nTesting key combinations...")
+    print("Test 1: 'ctrl+a' (select all)")
+    press_key_combination('ctrl+a')
+    time.sleep(1)
+
+    print("Test 2: 'delete'")
+    press_key_combination('delete')
+    time.sleep(1)
+
+    print("Test 3: 'alt+f4' (This would close the window, so we'll just print)")
+    print("(Skipping alt+f4 to not close the test)...")
+    # press_key_combination('alt+f4')
+    time.sleep(1)
+
+    print("Test 4: Invalid combo 'ctrl+alt+shift'")
+    press_key_combination('ctrl+alt+shift')
     time.sleep(1)
 
     print("\nAutomation test script finished.")

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import cv2
 from PIL import Image, ImageTk
 from screen_capture import capture_screen
 from image_analyzer import find_color, find_image
-from automation import click_at, right_click_at, type_text, click_and_drag, scroll_wheel
+from automation import click_at, right_click_at, type_text, click_and_drag, scroll_wheel, press_key_combination
 from settings_manager import SettingsManager
 
 class App(tk.Tk):
@@ -696,6 +696,10 @@ class App(tk.Tk):
                 text = action_params.get('text', '')
                 self.log(f"    - Performing action: Type '{text}'")
                 type_text(text)
+            elif action_type == "Key Combo":
+                key_combo = action_params.get('key_combo', '')
+                self.log(f"    - Performing action: Press keys '{key_combo}'")
+                press_key_combination(key_combo)
             elif action_type == "Scroll":
                 direction = action_params.get('scroll_direction', 'Down')
                 amount = action_params.get('scroll_amount', 5)
@@ -1163,6 +1167,7 @@ class StepEditor(tk.Toplevel):
         self.simple_click_offset_x = tk.StringVar(value=self.step_data.get('action_params', {}).get('click_offset_x', '0'))
         self.simple_click_offset_y = tk.StringVar(value=self.step_data.get('action_params', {}).get('click_offset_y', '0'))
         self.text_to_type = tk.StringVar(value=self.step_data.get('action_params', {}).get('text', ''))
+        self.key_combo_text = tk.StringVar(value=self.step_data.get('action_params', {}).get('key_combo', 'ctrl+c'))
         self.scroll_direction = tk.StringVar(value=self.step_data.get('action_params', {}).get('scroll_direction', 'Down'))
         self.scroll_amount = tk.StringVar(value=self.step_data.get('action_params', {}).get('scroll_amount', '5'))
         self.target_window_title = tk.StringVar(value=self.step_data.get('window_title', self.master.target_window_title.get() or ''))
@@ -1296,11 +1301,17 @@ class StepEditor(tk.Toplevel):
         tk.Radiobutton(action_frame, text="Right-click", variable=self.action_type, value="Right-click", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
         tk.Radiobutton(action_frame, text="Click with Offset", variable=self.action_type, value="Click with Offset", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
         tk.Radiobutton(action_frame, text="Type", variable=self.action_type, value="Type", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
+        tk.Radiobutton(action_frame, text="Key Combo", variable=self.action_type, value="Key Combo", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
         tk.Radiobutton(action_frame, text="Scroll", variable=self.action_type, value="Scroll", command=self.on_action_change, bg=self.master.bg_color, fg=self.master.text_color, selectcolor=self.master.widget_bg_color).pack(anchor="w")
 
         self.type_entry_frame = tk.Frame(action_frame, bg=self.master.bg_color)
         self.type_entry = tk.Entry(self.type_entry_frame, textvariable=self.text_to_type, bg=self.master.widget_bg_color, fg=self.master.text_color, relief=tk.FLAT)
         self.type_entry.pack(fill="x", padx=5, pady=5)
+
+        self.key_combo_frame = tk.Frame(action_frame, bg=self.master.bg_color)
+        tk.Label(self.key_combo_frame, text="Keys (e.g., ctrl+alt+delete):", bg=self.master.bg_color, fg=self.master.text_color).pack(side="left", padx=5)
+        self.key_combo_entry = tk.Entry(self.key_combo_frame, textvariable=self.key_combo_text, bg=self.master.widget_bg_color, fg=self.master.text_color, relief=tk.FLAT, width=20)
+        self.key_combo_entry.pack(side="left", fill="x", expand=True, padx=5, pady=5)
 
         self.simple_offset_frame = tk.Frame(action_frame, bg=self.master.bg_color)
         simple_offset_x_frame = tk.Frame(self.simple_offset_frame, bg=self.master.bg_color)
@@ -1553,11 +1564,14 @@ class StepEditor(tk.Toplevel):
         self.type_entry_frame.pack_forget()
         self.simple_offset_frame.pack_forget()
         self.scroll_frame.pack_forget()
+        self.key_combo_frame.pack_forget()
 
         if action == "Type":
             self.type_entry_frame.pack(fill="x", padx=5, pady=2)
         elif action == "Click with Offset":
             self.simple_offset_frame.pack(fill="x", padx=15, pady=2)
+        elif action == "Key Combo":
+            self.key_combo_frame.pack(fill="x", padx=5, pady=2)
         elif action == "Scroll":
             self.scroll_frame.pack(fill="x", padx=15, pady=2)
 
@@ -1631,6 +1645,8 @@ class StepEditor(tk.Toplevel):
             action_type = step['action_type']
             if action_type == 'Type':
                 step['action_params']['text'] = self.text_to_type.get()
+            elif action_type == 'Key Combo':
+                step['action_params']['key_combo'] = self.key_combo_text.get()
             elif action_type == 'Click with Offset':
                 try:
                     step['action_params']['click_offset_x'] = int(self.simple_click_offset_x.get())


### PR DESCRIPTION
This commit introduces a new "Key Combo" action type to the bot's capabilities.

- A new function `press_key_combination` is added to `automation.py` to handle pressing key combinations with modifiers (e.g., Ctrl, Alt, Shift). It includes parsing logic for a user-friendly string format like "ctrl+c".

- The `StepEditor` GUI in `main.py` is updated to include "Key Combo" as a selectable action. A text input is provided for the user to specify the key string.

- The application's main execution loop is updated to call the new function when a "Key Combo" step is encountered.

- The `README.md` file has been updated to reflect this change in the changelog and the project roadmap.